### PR TITLE
feat: add TaaS Admin App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# VS Code settings
+.vscode/

--- a/config/micro-frontends-config-local.json
+++ b/config/micro-frontends-config-local.json
@@ -1,6 +1,7 @@
 {
   "imports": {
     "@topcoder/micro-frontends-navbar-app": "http://localhost:3001/navbar/topcoder-micro-frontends-navbar-app.js",
+    "@topcoder/micro-frontends-taas-admin-app": "http://localhost:8502/taas-admin-app/topcoder-micro-frontends-taas-admin-app.js",
     "@topcoder/micro-frontends-react-app": "https://platform.topcoder-dev.com/react/topcoder-micro-frontends-react-app.js",
     "@topcoder/micro-frontends-angular-app": "https://platform.topcoder-dev.com/angular/main.js",
     "@topcoder/micro-frontends-teams": "https://platform.topcoder-dev.com/taas-app/topcoder-micro-frontends-teams.js",

--- a/config/micro-frontends-config-local.json
+++ b/config/micro-frontends-config-local.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "@topcoder/micro-frontends-navbar-app": "http://localhost:3001/navbar/topcoder-micro-frontends-navbar-app.js",
-    "@topcoder/micro-frontends-taas-admin-app": "http://localhost:8502/taas-admin-app/topcoder-micro-frontends-taas-admin-app.js",
+    "@topcoder/micro-frontends-taas-admin-app": "https://platform.topcoder-dev.com/taas-admin-app/topcoder-micro-frontends-taas-admin-app.js",
     "@topcoder/micro-frontends-react-app": "https://platform.topcoder-dev.com/react/topcoder-micro-frontends-react-app.js",
     "@topcoder/micro-frontends-angular-app": "https://platform.topcoder-dev.com/angular/main.js",
     "@topcoder/micro-frontends-teams": "https://platform.topcoder-dev.com/taas-app/topcoder-micro-frontends-teams.js",

--- a/config/micro-frontends-routes-local.txt
+++ b/config/micro-frontends-routes-local.txt
@@ -7,6 +7,9 @@
 <route path="taas">
   <application name="@topcoder/micro-frontends-teams"></application>
 </route>
+<route path="taas-admin">
+  <application name="@topcoder/micro-frontends-taas-admin-app"></application>
+</route>
 <route path="task-marketplace">
   <application name="@topcoder/micro-frontends-task-marketplace-app"></application>
 </route>


### PR DESCRIPTION
### Release Guide

This PR expects that TaaS Admin App is deployed on DEV to the next URL. If the TaaS Admin App would be deployed via a different URL, this line should be updated.

```
"@topcoder/micro-frontends-taas-admin-app": "https://platform.topcoder-dev.com/taas-admin-app/topcoder-micro-frontends-taas-admin-app.js",
```